### PR TITLE
deployment-app: Adjust settings to disallow anonymous

### DIFF
--- a/deployment-app.yaml
+++ b/deployment-app.yaml
@@ -30,7 +30,10 @@ spec:
           - {name: CMD_LOGLEVEL, value: "debug"}
 
           # Access control
-          - {name: CMD_ALLOW_ANONYMOUS_EDITS, value: "true"}
+          - {name: CMD_ALLOW_ANONYMOUS, value: "false"} # No anonymous
+          - {name: CMD_ALLOW_ANONYMOUS_EDITS, value: "true"} # ... but anonymous edits to existing notes allowed
+          - {name: CMD_ALLOW_FREEURL, value: "true"}
+          - {name: CMD_REQUIRE_FREEURL_AUTHENTICATION, value: "true"}
 
           # Performance
           - {name: CMD_TOOBUSY_LAG, value: "210"} # default 70


### PR DESCRIPTION
- Must be logged in to make notes
- But a note can be made freely editable, so it can be edited without being logged in
- Enable "freeurl" so you can have a note of any URL